### PR TITLE
Fix call to constants

### DIFF
--- a/README
+++ b/README
@@ -1,14 +1,14 @@
 CAW!!!
 
-CAW is a easily customizable taskbar written in Python.
+CAW is a easily customizable taskbar written in Python 2.x.
 
 Dependencies
 --
 
-libxcb 1.2
-xcb-proto 1.4
+libxcb 1.11
+xcb-proto 1.11
 xcb-util 0.3.4
-xpyb 1.1
+xpyb 1.3.1
 cairo 1.8.8
 pango 1.24.5
 
@@ -16,13 +16,13 @@ pango 1.24.5
 Building
 ---------
 
-python setup.py build
+python2 setup.py build
 
 
 Install
 --------
 
-python setup.py install
+python2 setup.py install
 
 
 Configuration

--- a/caw/caw.py
+++ b/caw/caw.py
@@ -245,7 +245,7 @@ class Caw:
         conn = self.connection
         scr = self.screen
         cookie = conn.core.GetProperty(False, scr.root, self._XROOTPMAP_ID,
-                xcb.XA_PIXMAP, 0, 10)
+                xproto.Atom.PIXMAP, 0, 10)
 
         rep = cookie.reply()
         if len(rep.value.buf()) < 4:
@@ -257,26 +257,26 @@ class Caw:
         scr = self.screen
         win = self.window
 
-        conn.core.ChangeProperty(xproto.PropMode.Replace, win, xcb.XA_WM_NAME, xcb.XA_STRING, 8, len("CAW!"), "CAW!")
+        conn.core.ChangeProperty(xproto.PropMode.Replace, win, xproto.Atom.WM_NAME, xproto.Atom.STRING, 8, len("CAW!"), "CAW!")
 
-        conn.core.ChangeProperty(xproto.PropMode.Replace, win, xcb.XA_WM_CLASS, xcb.XA_STRING, 8, len("caw\0CAW\0"), "caw\0CAW\0")
+        conn.core.ChangeProperty(xproto.PropMode.Replace, win, xproto.Atom.WM_CLASS, xproto.Atom.STRING, 8, len("caw\0CAW\0"), "caw\0CAW\0")
 
         cawc.set_hints(self.connection_c, self.window, self.x, self.y, self.width, self.height);
 
-        conn.core.ChangeProperty(xproto.PropMode.Replace, win, self._NET_WM_DESKTOP, xcb.XA_CARDINAL, 32, 1, struct.pack("I",0xffffffff))
+        conn.core.ChangeProperty(xproto.PropMode.Replace, win, self._NET_WM_DESKTOP, xproto.Atom.CARDINAL, 32, 1, struct.pack("I",0xffffffff))
 
-        conn.core.ChangeProperty(xproto.PropMode.Replace, win, self._WIN_STATE, xcb.XA_CARDINAL, 32, 1, struct.pack("I",1))
+        conn.core.ChangeProperty(xproto.PropMode.Replace, win, self._WIN_STATE, xproto.Atom.CARDINAL, 32, 1, struct.pack("I",1))
 
 
         conn.core.ChangeWindowAttributes(scr.root,
                 xproto.CW.EventMask, 
                 [xproto.EventMask.PropertyChange|xproto.EventMask.StructureNotify])
 
-        conn.core.ChangeProperty(xproto.PropMode.Replace, win, self._NET_WM_WINDOW_TYPE, xcb.XA_ATOM, 32, 1, struct.pack("I",self._NET_WM_WINDOW_TYPE_DOCK))
+        conn.core.ChangeProperty(xproto.PropMode.Replace, win, self._NET_WM_WINDOW_TYPE, xproto.Atom.ATOM, 32, 1, struct.pack("I",self._NET_WM_WINDOW_TYPE_DOCK))
         if self.above:
-            conn.core.ChangeProperty(xproto.PropMode.Replace, win, self._NET_WM_STATE, xcb.XA_ATOM, 32, 4, struct.pack("IIII",self._NET_WM_STATE_SKIP_TASKBAR, self._NET_WM_STATE_SKIP_PAGER, self._NET_WM_STATE_STICKY, self._NET_WM_STATE_ABOVE))
+            conn.core.ChangeProperty(xproto.PropMode.Replace, win, self._NET_WM_STATE, xproto.Atom.ATOM, 32, 4, struct.pack("IIII",self._NET_WM_STATE_SKIP_TASKBAR, self._NET_WM_STATE_SKIP_PAGER, self._NET_WM_STATE_STICKY, self._NET_WM_STATE_ABOVE))
         else:
-            conn.core.ChangeProperty(xproto.PropMode.Replace, win, self._NET_WM_STATE, xcb.XA_ATOM, 32, 4, struct.pack("IIII",self._NET_WM_STATE_SKIP_TASKBAR, self._NET_WM_STATE_SKIP_PAGER, self._NET_WM_STATE_STICKY, self._NET_WM_STATE_BELOW))
+            conn.core.ChangeProperty(xproto.PropMode.Replace, win, self._NET_WM_STATE, xproto.Atom.ATOM, 32, 4, struct.pack("IIII",self._NET_WM_STATE_SKIP_TASKBAR, self._NET_WM_STATE_SKIP_PAGER, self._NET_WM_STATE_STICKY, self._NET_WM_STATE_BELOW))
 
 
     def _update_struts(self):

--- a/caw/widgets/desktop.py
+++ b/caw/widgets/desktop.py
@@ -1,5 +1,6 @@
 import caw.widget
 import xcb
+import xcb.xproto as xproto
 import struct
 
 class Desktop(caw.widget.Widget):
@@ -49,7 +50,7 @@ class Desktop(caw.widget.Widget):
         totalc = conn.core.GetProperty(0,
                 scr.root,
                 self._NET_NUMBER_OF_DESKTOPS,
-                xcb.XA_CARDINAL,
+                xproto.Atom.CARDINAL,
                 0,
                 12)
 
@@ -80,7 +81,7 @@ class Desktop(caw.widget.Widget):
         conn = self.parent.connection
         scr = self.parent.screen
         currc = conn.core.GetProperty(0, scr.root, self._NET_CURRENT_DESKTOP,
-                xcb.XA_CARDINAL, 0, 12)
+                xproto.Atom.CARDINAL, 0, 12)
         currp = currc.reply()
         self.current = struct.unpack_from("I", currp.value.buf())[0]
         self.width_hint = self.parent.text_width(self._output())

--- a/caw/widgets/tasklist.py
+++ b/caw/widgets/tasklist.py
@@ -117,7 +117,7 @@ class Tasklist(caw.widget.Widget):
 
         self.parent.atoms[self._NET_WM_DESKTOP].append(self._update_desktop)
         self.parent.atoms[self._NET_CLIENT_LIST].append(self._update_clients)
-        self.parent.atoms[xcb.XA_WM_NAME].append(self._update_name)
+        self.parent.atoms[xproto.Atom.WM_NAME].append(self._update_name)
         self.parent.atoms[self._NET_WM_NAME].append(self._update_name)
         self.parent.events[xproto.FocusInEvent].append(self._update_focus)
         self.parent.events[xproto.DestroyNotifyEvent].append(self._destroynotify)
@@ -130,7 +130,7 @@ class Tasklist(caw.widget.Widget):
         conn = self.parent.connection
         scr = self.parent.screen
         currc = conn.core.GetProperty(0, scr.root, self._NET_NUMBER_OF_DESKTOPS,
-                xcb.XA_CARDINAL, 0, 12)
+                xproto.Atom.CARDINAL, 0, 12)
         currp = currc.reply()
         self.number_of_desktops = struct.unpack_from("I", currp.value.buf())[0]
 
@@ -140,7 +140,7 @@ class Tasklist(caw.widget.Widget):
         conn = self.parent.connection
         scr = self.parent.screen
         currc = conn.core.GetProperty(0, scr.root, self._NET_CURRENT_DESKTOP,
-                xcb.XA_CARDINAL, 0, 12)
+                xproto.Atom.CARDINAL, 0, 12)
         currp = currc.reply()
         self.current_desktop = struct.unpack_from("I", currp.value.buf())[0]
         nf = self._next_focus.get(self.current_desktop, 0)
@@ -175,7 +175,7 @@ class Tasklist(caw.widget.Widget):
         #event = struct.pack('BBHII5I', 33, 32, 0, win, self.WM_CHANGE_STATE, 3,0,0,0,0)
         #e = conn.core.SendEvent(0, win, 0xffffff, event)
         #print e.check()
-        #conn.core.ChangeProperty(xproto.PropMode.Replace, win, self.WM_CHANGE_STATE, xcb.XA_ATOM, 32, 1, struct.pack("I",self._NET_WM_STATE_HIDDEN))
+        #conn.core.ChangeProperty(xproto.PropMode.Replace, win, self.WM_CHANGE_STATE, xproto.Atom.ATOM, 32, 1, struct.pack("I",self._NET_WM_STATE_HIDDEN))
 
         return
 
@@ -184,7 +184,7 @@ class Tasklist(caw.widget.Widget):
         conn = self.parent.connection
         id = evt.window
         if id in self.clients:
-            r = conn.core.GetProperty(0, id, self._NET_WM_STATE, xcb.XA_ATOM, 0, 2**16).reply()
+            r = conn.core.GetProperty(0, id, self._NET_WM_STATE, xproto.Atom.ATOM, 0, 2**16).reply()
             state = struct.unpack_from('%dI' % r.value_len, r.value.buf())
             #print state
             if self._NET_WM_STATE_HIDDEN in state:
@@ -198,7 +198,7 @@ class Tasklist(caw.widget.Widget):
         if id in self.clients:
             r = conn.core.GetProperty(0, id, self._NET_WM_NAME, 0, 0, 2**16).reply()
             if not r.value_len:
-                r = conn.core.GetProperty(0, id, xcb.XA_WM_NAME, 0, 0, 2**16).reply()
+                r = conn.core.GetProperty(0, id, xproto.Atom.WM_NAME, 0, 0, 2**16).reply()
             val = struct.unpack_from('%ds' % r.value_len, r.value.buf())[0]
             #print "updated name value:", val, r.value_len, r.value.buf()
             self.clients[id]['name'] = val.strip("\x00")
@@ -208,7 +208,7 @@ class Tasklist(caw.widget.Widget):
         conn = self.parent.connection
         id = evt.window
         if id in self.clients:
-            r = conn.core.GetProperty(0, id, self._NET_WM_DESKTOP, xcb.XA_CARDINAL, 0, 12).reply()
+            r = conn.core.GetProperty(0, id, self._NET_WM_DESKTOP, xproto.Atom.CARDINAL, 0, 12).reply()
             #print "updating desktop:", id, self.clients[id]['name'], r.value_len
             if r.value_len > 0:
                 self.clients[id]['desktop'] = struct.unpack_from('I',r.value.buf())[0]
@@ -222,7 +222,7 @@ class Tasklist(caw.widget.Widget):
         clientsc = conn.core.GetProperty(0,
                 scr.root,
                 self._NET_CLIENT_LIST,
-                xcb.XA_WINDOW,
+                xproto.Atom.WINDOW,
                 0,
                 2**16)
 
@@ -237,11 +237,11 @@ class Tasklist(caw.widget.Widget):
 
         for id in clients:
             if id not in self.clients and id != self.parent.window:
-                classes[id] = conn.core.GetProperty(0, id, xcb.XA_WM_CLASS, xcb.XA_STRING, 0, 2**16)
-                desktops[id] = conn.core.GetProperty(0, id, self._NET_WM_DESKTOP, xcb.XA_CARDINAL, 0, 12)
+                classes[id] = conn.core.GetProperty(0, id, xproto.Atom.WM_CLASS, xproto.Atom.STRING, 0, 2**16)
+                desktops[id] = conn.core.GetProperty(0, id, self._NET_WM_DESKTOP, xproto.Atom.CARDINAL, 0, 12)
                 names[id] = conn.core.GetProperty(0, id, self._NET_WM_NAME, 0, 0, 2**16)
-                names_alt[id] = conn.core.GetProperty(0, id, xcb.XA_WM_NAME, 0, 0, 2**16)
-                states[id] = conn.core.GetProperty(0, id, self._NET_WM_STATE, xcb.XA_ATOM, 0, 2**16)
+                names_alt[id] = conn.core.GetProperty(0, id, xproto.Atom.WM_NAME, 0, 0, 2**16)
+                states[id] = conn.core.GetProperty(0, id, self._NET_WM_STATE, xproto.Atom.ATOM, 0, 2**16)
 
         for id in classes:
             #print "new window:", id


### PR DESCRIPTION
The stuff moved from the xcb module into the xproto submodule (class Atom)

This change requires to adjust the dependencies (I assume latest versions, as I couldn't find out when this changed)
 * xpyb >= 1.3.1 (Debian squeeze still using 1.2 is the only problem)
 * libxcb >=1.11
 * xcb-proto >=1.11