### PR TITLE
Add support for the xpyb replacement xcffib

### DIFF
--- a/README
+++ b/README
@@ -8,7 +8,7 @@ Dependencies
 libxcb 1.11
 xcb-proto 1.11
 xcb-util 0.3.4
-xpyb 1.3.1
+xpyb 1.3.1 OR xcffib 0.2.2
 cairo 1.8.8
 pango 1.24.5
 

--- a/caw/caw.py
+++ b/caw/caw.py
@@ -1,7 +1,11 @@
 import select
 import collections
-import xcb
-import xcb.xproto as xproto
+try:
+    import xcffib as xcb
+    import xcffib.xproto as xproto
+except:
+    import xcb
+    import xcb.xproto as xproto
 import struct
 import array
 import sys
@@ -223,9 +227,9 @@ class Caw:
 
     def _init_atoms(self):
         a = self.get_atoms([
-                "_NET_WM_WINDOW_TYPE", 
-                "_NET_WM_WINDOW_TYPE_DOCK", 
-                "_NET_WM_WINDOW_TYPE_DESKTOP", 
+                "_NET_WM_WINDOW_TYPE",
+                "_NET_WM_WINDOW_TYPE_DOCK",
+                "_NET_WM_WINDOW_TYPE_DESKTOP",
                 "_NET_WM_DESKTOP",
                 "_NET_WM_STATE",
                 "_NET_WM_STATE_SKIP_PAGER",
@@ -269,7 +273,7 @@ class Caw:
 
 
         conn.core.ChangeWindowAttributes(scr.root,
-                xproto.CW.EventMask, 
+                xproto.CW.EventMask,
                 [xproto.EventMask.PropertyChange|xproto.EventMask.StructureNotify])
 
         conn.core.ChangeProperty(xproto.PropMode.Replace, win, self._NET_WM_WINDOW_TYPE, xproto.Atom.ATOM, 32, 1, struct.pack("I",self._NET_WM_WINDOW_TYPE_DOCK))

--- a/caw/widgets/desktop.py
+++ b/caw/widgets/desktop.py
@@ -1,7 +1,12 @@
 import caw.widget
-import xcb
-import xcb.xproto as xproto
 import struct
+try:
+    import xcffib as xcb
+    import xcffib.xproto as xproto
+except:
+    import xcb
+    import xcb.xproto as xproto
+
 
 class Desktop(caw.widget.Widget):
     """Desktop name Widget
@@ -65,7 +70,7 @@ class Desktop(caw.widget.Widget):
         self.num_desktops = struct.unpack_from("I", totalr.value.buf())[0]
 
         namesr = namesc.reply()
-        self.desktops = struct.unpack_from("%ds" % namesr.value_len, 
+        self.desktops = struct.unpack_from("%ds" % namesr.value_len,
                 namesr.value.buf())[0].strip("\x00").split("\x00")
 
         self._update()
@@ -103,4 +108,3 @@ class Desktop(caw.widget.Widget):
 
         else:
             self.parent.draw_text(self.desktops[self.current], self.current_fg)
-

--- a/caw/widgets/systray.py
+++ b/caw/widgets/systray.py
@@ -1,6 +1,10 @@
 import caw.widget
-import xcb
-import xcb.xproto as xproto
+try:
+    import xcffib as xcb
+    import xcffib.xproto as xproto
+except:
+    import xcb
+    import xcb.xproto as xproto
 import caw.cawc as cawc
 
 class Systray(caw.widget.Widget):
@@ -106,7 +110,7 @@ class Systray(caw.widget.Widget):
         return
 
         #self.parent.connection.core.ConfigureWindow(
-        #        window, 
+        #        window,
         #        (xproto.ConfigWindow.X |
         #        xproto.ConfigWindow.Y |
         #        xproto.ConfigWindow.Width |
@@ -142,4 +146,3 @@ class Systray(caw.widget.Widget):
             conn.core.MapWindow(taskwin)
             conn.flush()
             curx += task['width'] + self.spacing
-

--- a/caw/widgets/tasklist.py
+++ b/caw/widgets/tasklist.py
@@ -1,7 +1,12 @@
 import caw.widget
-import xcb
 import struct
-import xcb.xproto as xproto
+try:
+    import xcffib as xcb
+    import xcffib.xproto as xproto
+except:
+    import xcb
+    import xcb.xproto as xproto
+
 
 class Tasklist(caw.widget.Widget):
     """Basic tasklist.
@@ -374,5 +379,3 @@ class Tasklist(caw.widget.Widget):
 ##
 #                self.parent.draw_text(c['name'][:trim] + '...', normal_fg, x)
             curx += percli + self.spacing
-
-

--- a/setup.py
+++ b/setup.py
@@ -5,9 +5,13 @@ import commands
 
 # Check for Python Xlib
 try:
-    import xcb
+    try:
+        import xcffib
+    except:
+        import xcb
 except:
-    print "\nCaw! requires the XPYB"
+    print "\nCaw! requires xcffib or XPYB"
+    print "https://pypi.python.org/pypi/xcffib/"
     print "http://sourceforge.net/projects/python-xlib/"
     sys.exit()
 


### PR DESCRIPTION
Requirement for xcffib is 0.2.2 and above

_____
Mainly done because it's more active and the documentations seems to be better. Hopefully I can now track the issue with caw segfaulting because of
>AttributeError: 'NoExposureEvent' object has no attribute 'type'

on https://github.com/milkypostman/caw/blob/master/caw/caw.py#L359